### PR TITLE
Fix incorrect message height for custom font

### DIFF
--- a/Classes/UNAlertView.swift
+++ b/Classes/UNAlertView.swift
@@ -133,11 +133,11 @@ final public class UNAlertView: UIView {
         
         // Message
         messageLabel.numberOfLines = 0
+        messageLabel.font = (messageFont != nil) ? messageFont : UIFont.systemFontOfSize(16)
         let messageSize    = messageLabel.sizeThatFits(CGSize(width: kContainerWidth-44, height: 9999))
         messageLabel.frame = CGRect(x: 22, y: currentContentHeight + 10, width: kContainerWidth-44, height: messageSize.height)
         currentContentHeight = getBottomPos(messageLabel)
         messageLabel.textAlignment = messageAlignment
-        messageLabel.font = (messageFont != nil) ? messageFont : UIFont.systemFontOfSize(16)
         containerView.addSubview(messageLabel)
         
         


### PR DESCRIPTION
The `messageLabel` font needs to be set beforehand in order to get the correct `messageSize`
