### PR TITLE
Manual alert dismissal option

### DIFF
--- a/Classes/UNAlertView.swift
+++ b/Classes/UNAlertView.swift
@@ -13,7 +13,7 @@ private let kButtonHeight: CGFloat   = 50.0
 private let kUNAlertViewTag          = 1928
 private let kCornerRadius: CGFloat   = 6.0
 private let kShadowOpacity: Float    = 0.15
-
+private var autoDismiss: Bool        = true
 internal enum UNButtonAlignment {
     case Horizontal
     case Vertical
@@ -190,6 +190,7 @@ final public class UNAlertView: UIView {
         
     }
     
+    
     // Dismiss the alertview from the keywindow
     private func dismiss() {
         
@@ -210,7 +211,16 @@ final public class UNAlertView: UIView {
     func buttonTapped(btn:UNAlertButton) {
         
         btn.action()
+        if (autoDismiss) {
+            dismiss()
+        }
+    }
+    
+    func dismissAlert() {
         dismiss()
+    }
+    func setAutoDismiss(autoStatus: Bool) {
+        autoDismiss = autoStatus
     }
     
     private func getBottomPos(view: UIView) -> CGFloat {


### PR DESCRIPTION
Added autoDismiss: Bool attribute that defaults to true, enabling the default behavior to be the same as it is in master. 

If set (using setAutoDismiss(Bool)) to false the window will not automatically close when a button is pressed, allowing the calling code to manage the window life-cycle more directly. 

Great for use cases where you want to have an extended interaction with in the UIAlert window (ex: text to speech, reply actions etc). 

Calling code can use new 'dismissAlert()' feature as a proxy for private dismiss() function. Alternative would be to make dismiss() public but felt it beyond my purview to change the existing method signatures. Recommend doing that though..
